### PR TITLE
External loading of texture atlases

### DIFF
--- a/Spine-macOS/Info.plist
+++ b/Spine-macOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Spine-tvOS/Info.plist
+++ b/Spine-tvOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Spine-watchOS/Info.plist
+++ b/Spine-watchOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Spine.podspec
+++ b/Spine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Spine"
-  s.version      = "1.1.2"
+  s.version      = "1.2.0"
   s.summary      = "Unofficial Spine runtime library for iOS, macOS, tvOS and watchOS"
   s.description  = <<-DESC
                     This library allows you to play animations created with the Spine App: http://esotericsoftware.com

--- a/Spine.xcodeproj/project.pbxproj
+++ b/Spine.xcodeproj/project.pbxproj
@@ -12,6 +12,18 @@
 		770640A02028F86C0031BD32 /* SpineModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7706409F2028F86C0031BD32 /* SpineModelTests.swift */; };
 		770D466B203CADC60046092C /* Skeleton+Skins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770D466A203CADC60046092C /* Skeleton+Skins.swift */; };
 		770D466D203CC6BE0046092C /* SKAction+Spine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770D466C203CC6BE0046092C /* SKAction+Spine.swift */; };
+		7711235420EEC00C00BFF103 /* SpineModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235320EEC00C00BFF103 /* SpineModel+Atlases.swift */; };
+		7711235520EEC00C00BFF103 /* SpineModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235320EEC00C00BFF103 /* SpineModel+Atlases.swift */; };
+		7711235620EEC00C00BFF103 /* SpineModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235320EEC00C00BFF103 /* SpineModel+Atlases.swift */; };
+		7711235720EEC00C00BFF103 /* SpineModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235320EEC00C00BFF103 /* SpineModel+Atlases.swift */; };
+		7711235920EEC13000BFF103 /* SkinModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235820EEC13000BFF103 /* SkinModel+Atlases.swift */; };
+		7711235A20EEC13000BFF103 /* SkinModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235820EEC13000BFF103 /* SkinModel+Atlases.swift */; };
+		7711235B20EEC13000BFF103 /* SkinModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235820EEC13000BFF103 /* SkinModel+Atlases.swift */; };
+		7711235C20EEC13000BFF103 /* SkinModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235820EEC13000BFF103 /* SkinModel+Atlases.swift */; };
+		7711235E20EEC1F200BFF103 /* SkinSlotModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235D20EEC1F200BFF103 /* SkinSlotModel+Atlases.swift */; };
+		7711235F20EEC1F200BFF103 /* SkinSlotModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235D20EEC1F200BFF103 /* SkinSlotModel+Atlases.swift */; };
+		7711236020EEC1F200BFF103 /* SkinSlotModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235D20EEC1F200BFF103 /* SkinSlotModel+Atlases.swift */; };
+		7711236120EEC1F200BFF103 /* SkinSlotModel+Atlases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7711235D20EEC1F200BFF103 /* SkinSlotModel+Atlases.swift */; };
 		773E8FDE2024ED4B009E38BD /* BoneKeyframeRotateModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773E8FDD2024ED4B009E38BD /* BoneKeyframeRotateModelTests.swift */; };
 		773E8FE02024EDF8009E38BD /* BoneKeyframeTranslateModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773E8FDF2024EDF8009E38BD /* BoneKeyframeTranslateModelTests.swift */; };
 		773E8FE22024F04D009E38BD /* BoneKeyframeScaleModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773E8FE12024F04D009E38BD /* BoneKeyframeScaleModelTests.swift */; };
@@ -217,6 +229,9 @@
 		7706409F2028F86C0031BD32 /* SpineModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpineModelTests.swift; sourceTree = "<group>"; };
 		770D466A203CADC60046092C /* Skeleton+Skins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Skeleton+Skins.swift"; sourceTree = "<group>"; };
 		770D466C203CC6BE0046092C /* SKAction+Spine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKAction+Spine.swift"; sourceTree = "<group>"; };
+		7711235320EEC00C00BFF103 /* SpineModel+Atlases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SpineModel+Atlases.swift"; sourceTree = "<group>"; };
+		7711235820EEC13000BFF103 /* SkinModel+Atlases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SkinModel+Atlases.swift"; sourceTree = "<group>"; };
+		7711235D20EEC1F200BFF103 /* SkinSlotModel+Atlases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SkinSlotModel+Atlases.swift"; sourceTree = "<group>"; };
 		773E8FDD2024ED4B009E38BD /* BoneKeyframeRotateModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoneKeyframeRotateModelTests.swift; sourceTree = "<group>"; };
 		773E8FDF2024EDF8009E38BD /* BoneKeyframeTranslateModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoneKeyframeTranslateModelTests.swift; sourceTree = "<group>"; };
 		773E8FE12024F04D009E38BD /* BoneKeyframeScaleModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoneKeyframeScaleModelTests.swift; sourceTree = "<group>"; };
@@ -452,6 +467,9 @@
 				774D0C8F203CD62900EC5156 /* Skeleton+Defaultable.swift */,
 				77869DEF20386A8D00404AC8 /* CGPath+Spine.swift */,
 				770D466C203CC6BE0046092C /* SKAction+Spine.swift */,
+				7711235320EEC00C00BFF103 /* SpineModel+Atlases.swift */,
+				7711235820EEC13000BFF103 /* SkinModel+Atlases.swift */,
+				7711235D20EEC1F200BFF103 /* SkinSlotModel+Atlases.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -836,9 +854,12 @@
 			files = (
 				77689E7F203EE2FA002E0FDB /* Skeleton+Points.swift in Sources */,
 				77689E7B203EE2FA002E0FDB /* Skeleton+Atlases.swift in Sources */,
+				7711235520EEC00C00BFF103 /* SpineModel+Atlases.swift in Sources */,
 				77689E76203EE2E0002E0FDB /* AnimationModels.swift in Sources */,
 				77689E7D203EE2FA002E0FDB /* Skeleton+Animations.swift in Sources */,
 				77689E6B203EE2C5002E0FDB /* Skeleton.swift in Sources */,
+				7711235A20EEC13000BFF103 /* SkinModel+Atlases.swift in Sources */,
+				7711235F20EEC1F200BFF103 /* SkinSlotModel+Atlases.swift in Sources */,
 				77689E6D203EE2D2002E0FDB /* Slot.swift in Sources */,
 				77689E80203EE2FA002E0FDB /* Skeleton+Defaultable.swift in Sources */,
 				77689E7A203EE2EF002E0FDB /* BezierCurveSolver.swift in Sources */,
@@ -898,9 +919,12 @@
 			files = (
 				77689ECD203EE9C8002E0FDB /* Skeleton+Points.swift in Sources */,
 				77689EC9203EE9C8002E0FDB /* Skeleton+Atlases.swift in Sources */,
+				7711235620EEC00C00BFF103 /* SpineModel+Atlases.swift in Sources */,
 				77689EC4203EE9BD002E0FDB /* AnimationModels.swift in Sources */,
 				77689ECB203EE9C8002E0FDB /* Skeleton+Animations.swift in Sources */,
 				77689EB9203EE9B9002E0FDB /* Skeleton.swift in Sources */,
+				7711235B20EEC13000BFF103 /* SkinModel+Atlases.swift in Sources */,
+				7711236020EEC1F200BFF103 /* SkinSlotModel+Atlases.swift in Sources */,
 				77689EBB203EE9B9002E0FDB /* Slot.swift in Sources */,
 				77689ECE203EE9C8002E0FDB /* Skeleton+Defaultable.swift in Sources */,
 				77689EC8203EE9C4002E0FDB /* BezierCurveSolver.swift in Sources */,
@@ -960,9 +984,12 @@
 			files = (
 				77689F18203EEB73002E0FDB /* Skeleton+Points.swift in Sources */,
 				77689F14203EEB73002E0FDB /* Skeleton+Atlases.swift in Sources */,
+				7711235720EEC00C00BFF103 /* SpineModel+Atlases.swift in Sources */,
 				77689F0F203EEB68002E0FDB /* AnimationModels.swift in Sources */,
 				77689F16203EEB73002E0FDB /* Skeleton+Animations.swift in Sources */,
 				77689F04203EEB64002E0FDB /* Skeleton.swift in Sources */,
+				7711235C20EEC13000BFF103 /* SkinModel+Atlases.swift in Sources */,
+				7711236120EEC1F200BFF103 /* SkinSlotModel+Atlases.swift in Sources */,
 				77689F06203EEB64002E0FDB /* Slot.swift in Sources */,
 				77689F19203EEB73002E0FDB /* Skeleton+Defaultable.swift in Sources */,
 				77689F13203EEB6F002E0FDB /* BezierCurveSolver.swift in Sources */,
@@ -991,9 +1018,12 @@
 			files = (
 				77E5A8C7202CED6F00ACDC0D /* Prefixable.swift in Sources */,
 				776656E7202BADBB00750189 /* Skin.swift in Sources */,
+				7711235420EEC00C00BFF103 /* SpineModel+Atlases.swift in Sources */,
 				775D969420336DCC00137B38 /* BezierCurveSolver.swift in Sources */,
 				770D466D203CC6BE0046092C /* SKAction+Spine.swift in Sources */,
 				77E6FFB62029C8510078923C /* Bone.swift in Sources */,
+				7711235920EEC13000BFF103 /* SkinModel+Atlases.swift in Sources */,
+				7711235E20EEC1F200BFF103 /* SkinSlotModel+Atlases.swift in Sources */,
 				779AC33A201B4A8A00C33B79 /* ConstraintsModels.swift in Sources */,
 				779AC344201B4C4D00C33B79 /* AnimationModels.swift in Sources */,
 				770D466B203CADC60046092C /* Skeleton+Skins.swift in Sources */,

--- a/Spine/Extensions/SkinModel+Atlases.swift
+++ b/Spine/Extensions/SkinModel+Atlases.swift
@@ -1,0 +1,33 @@
+//
+//  SkinModel+Atlases.swift
+//  Spine
+//
+//  Created by Max Gribov on 06/07/2018.
+//  Copyright © 2018 Max Gribov. All rights reserved.
+//
+
+import Foundation
+
+extension SkinModel {
+    
+    func atlasesNames() -> [String]? {
+        
+        guard let slots = slots else {
+            
+            return nil
+        }
+        
+        var names = Set<String>()
+        
+        for slot in slots {
+            
+            guard let atlasesNames = slot.atlasesNames() else {
+                continue
+            }
+            
+            names = names.union(Set(atlasesNames))
+        }
+        
+        return Array(names)
+    }
+}

--- a/Spine/Extensions/SkinSlotModel+Atlases.swift
+++ b/Spine/Extensions/SkinSlotModel+Atlases.swift
@@ -1,0 +1,34 @@
+//
+//  SkinSlotModel+Atlases.swift
+//  Spine
+//
+//  Created by Max Gribov on 06/07/2018.
+//  Copyright © 2018 Max Gribov. All rights reserved.
+//
+
+import SpriteKit
+
+extension SkinSlotModel {
+    
+    func atlasesNames() -> [String]? {
+        
+        var names = Set<String>()
+
+        guard let attachments = attachments else {
+            
+            return nil
+        }
+        
+        for attachment in attachments {
+            
+            guard let attachmentAtlasName = atlasName(for: attachment) else {
+                
+                continue
+            }
+            
+            names.insert(attachmentAtlasName)
+        }
+
+        return Array(names)
+    }
+}

--- a/Spine/Extensions/SpineModel+Atlases.swift
+++ b/Spine/Extensions/SpineModel+Atlases.swift
@@ -1,0 +1,33 @@
+//
+//  SpineModel+Atlases.swift
+//  Spine
+//
+//  Created by Max Gribov on 06/07/2018.
+//  Copyright © 2018 Max Gribov. All rights reserved.
+//
+
+import SpriteKit
+
+public extension SpineModel {
+    
+    func atlasesNames() -> [String]? {
+        
+        guard let skins = skins else {
+            
+            return nil
+        }
+        
+        var names = Set<String>()
+        
+        for skin in skins {
+            
+            guard let atlasesNames = skin.atlasesNames() else {
+                continue
+            }
+            
+            names = names.union(Set(atlasesNames))
+        }
+        
+        return Array(names)
+    }
+}

--- a/Spine/Info.plist
+++ b/Spine/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Spine/Skeleton.swift
+++ b/Spine/Skeleton.swift
@@ -38,6 +38,21 @@ public class Skeleton: SKNode {
     }
     
     /**
+     Creates a skeleton node with an 'SpineModel' and atlases dictionary.
+
+     - parameter model: the skeleton model.
+     - parameter atlases: atlases dictionary
+     */
+    public init(_ model: SpineModel, _ atlases: [String : SKTextureAtlas]) {
+        
+        super.init()
+        self.createBones(model)
+        self.createSlots(model)
+        self.createSkins(model, atlases)
+        self.createAnimations(model)
+    }
+    
+    /**
      Сreates a skeleton node based on the json file stored in the bundle application.
      
      The initializer may fail, so returning value *optional*
@@ -118,6 +133,14 @@ public class Skeleton: SKNode {
         self.skins = model.skins?.map({ (skinModel) -> Skin in
             
             return Skin(skinModel, atlas: folder)
+        })
+    }
+    
+    func createSkins(_ model: SpineModel, _ atlases: [String : SKTextureAtlas]) {
+        
+        self.skins = model.skins?.map({ (skinModel) -> Skin in
+            
+            return Skin(skinModel, atlases)
         })
     }
     

--- a/Spine/Skin.swift
+++ b/Spine/Skin.swift
@@ -17,7 +17,7 @@ class Skin {
         
         self.model = model
         
-        guard let atlasesNames = atlasesNames(from: model) else {
+        guard let atlasesNames = model.atlasesNames() else {
             
             self.atlases = nil
             return
@@ -108,62 +108,11 @@ func atlasName(from name: String, actualName: String?, path: String?) -> String 
 }
 
 func atlasName(for attachmentType: AttachmentModelType ) -> String? {
-    
+
     switch attachmentType {
     case .region(let region): return atlasName(from: region.name, actualName: region.actualName, path: region.path)
     case .mesh(let mesh): return atlasName(from: mesh.name, actualName: mesh.actualName, path: mesh.path)
     case .linkedMesh(let linkedMesh): return atlasName(from: linkedMesh.name, actualName: linkedMesh.actualName, path: linkedMesh.path)
     default: return nil
     }
-}
-
-func atlasesNames(from skin: SkinModel) -> [String]? {
-
-    guard let slots = skin.slots else {
-        
-        return nil
-    }
-    
-    var names = Set<String>()
-    
-    for slot in slots {
-        
-        guard let attachments = slot.attachments else {
-            
-            continue
-        }
-        
-        for attachment in attachments {
-            
-            guard let attachmentAtlasName = atlasName(for: attachment) else {
-                
-                continue
-            }
-            
-            names.insert(attachmentAtlasName)
-        }
-    }
-    
-    return Array(names)
-}
-
-func atlasesNames(from skins: [SkinModel]? ) -> [String]? {
-    
-    guard let skins = skins else {
-        
-        return nil
-    }
-    
-    var names = Set<String>()
-    
-    for skin in skins {
-        
-        guard let skinNames = atlasesNames(from: skin) else {
-            continue
-        }
-        
-        names = names.union(Set(skinNames))
-    }
-    
-    return Array(names)
 }

--- a/Spine/Skin.swift
+++ b/Spine/Skin.swift
@@ -40,6 +40,12 @@ class Skin {
         self.atlases = atlases
     }
     
+    init(_ model: SkinModel, _ atlases: [String : SKTextureAtlas]) {
+        
+        self.model = model
+        self.atlases = atlases
+    }
+    
     func attachment(_ model: AttachmentModelType) -> Attachment? {
         
         if AttachmentBuilder.textureRequired(for: model) {


### PR DESCRIPTION
To simplify the task of managing assets added public API allows you to create skeletons on the basis of externally loaded model and texture atlases. This allows for relatively large projects to centrally load textures for all the characters in the scene.